### PR TITLE
Store the current count value locally

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -15,12 +15,20 @@
 
 <script setup lang="ts">
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 
 const count = ref(0);
 
+onMounted(() => {
+  const storedCount = localStorage.getItem('count');
+  if (storedCount !== null) {
+    count.value = parseInt(storedCount, 10);
+  }
+});
+
 function incrementCount() {
   count.value++;
+  localStorage.setItem('count', count.value.toString());
 }
 </script>
 

--- a/tests/e2e/specs/test.cy.ts
+++ b/tests/e2e/specs/test.cy.ts
@@ -14,4 +14,19 @@ describe('Home Page Tests', () => {
     cy.get('.count-button').click()
     cy.get('.number-display').should('contain', '1')
   })
+
+  it('Checks if the stored count value is displayed on page load', () => {
+    localStorage.setItem('count', '5');
+    cy.visit('/')
+    cy.get('.number-display').should('contain', '5')
+  })
+
+  it('Checks if the new count value is stored in local storage after button click', () => {
+    cy.visit('/')
+    cy.get('.count-button').click()
+    cy.get('.number-display').should('contain', '1')
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('count')).to.equal('1')
+    })
+  })
 })


### PR DESCRIPTION
Fixes #5

Store the current count value locally.

* Import `onMounted` from `vue` in `src/views/HomePage.vue`.
* Add `onMounted` lifecycle hook to check for stored count value in local storage and set `count` in `src/views/HomePage.vue`.
* Update `incrementCount` function to store the new count value in local storage in `src/views/HomePage.vue`.
* Add test to check if the stored count value is displayed on page load in `tests/e2e/specs/test.cy.ts`.
* Add test to check if the new count value is stored in local storage after button click in `tests/e2e/specs/test.cy.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/notch/pull/6?shareId=808d818b-7d35-4d20-a81a-4cd0df7dc76a).