### PR TITLE
Add settings page and fix navigation bug

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from '@ionic/vue-router';
 import { RouteRecordRaw } from 'vue-router';
-import HomePage from '../views/HomePage.vue'
+import HomePage from '../views/HomePage.vue';
+import SettingsPage from '../views/SettingsPage.vue';
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -11,6 +12,11 @@ const routes: Array<RouteRecordRaw> = [
     path: '/home',
     name: 'Home',
     component: HomePage
+  },
+  {
+    path: '/settings',
+    name: 'Settings',
+    component: SettingsPage
   }
 ]
 

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -9,6 +9,7 @@
     <ion-content :fullscreen="true">
       <div class="number-display">{{ count }}</div>
       <button class="count-button" @click="incrementCount">count</button>
+      <button class="settings-button" @click="goToSettings">Settings</button>
     </ion-content>
   </ion-page>
 </template>
@@ -16,8 +17,10 @@
 <script setup lang="ts">
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
 import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
 
 const count = ref(0);
+const router = useRouter();
 
 onMounted(() => {
   const storedCount = localStorage.getItem('count');
@@ -30,6 +33,10 @@ function incrementCount() {
   count.value++;
   localStorage.setItem('count', count.value.toString());
 }
+
+function goToSettings() {
+  router.push('/settings');
+}
 </script>
 
 <style scoped>
@@ -40,6 +47,13 @@ function incrementCount() {
 }
 
 .count-button {
+  display: block;
+  margin: 20px auto;
+  padding: 10px 20px;
+  font-size: 24px;
+}
+
+.settings-button {
   display: block;
   margin: 20px auto;
   padding: 10px 20px;

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -1,0 +1,36 @@
+<template>
+  <ion-page>
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-title>Settings</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content :fullscreen="true">
+      <div class="settings-container">
+        <h2>Settings Page</h2>
+        <p>Here you can configure your settings.</p>
+      </div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
+</script>
+
+<style scoped>
+.settings-container {
+  text-align: center;
+  margin-top: 20%;
+}
+
+.settings-container h2 {
+  font-size: 24px;
+  margin-bottom: 10px;
+}
+
+.settings-container p {
+  font-size: 18px;
+}
+</style>


### PR DESCRIPTION
Fixes #9

Add navigation to Settings page from Home page.

* **HomePage.vue**:
  - Import `useRouter` from `vue-router`.
  - Define `goToSettings` function to navigate to `/settings` using `router.push`.
  - Add a button in the template that calls `goToSettings` on click.
  - Add styles for the new settings button.

* **router/index.ts**:
  - Import `SettingsPage` component.
  - Add a new route for the settings page with path `/settings`.

* **SettingsPage.vue**:
  - Create a new `SettingsPage.vue` component with basic template, script, and style.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/notch/pull/10?shareId=25e32272-8331-4d61-b7f0-1e37e0fa448b).