### PR TITLE
Better settings page

### DIFF
--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -10,6 +10,7 @@
       <div class="settings-container">
         <h2>Settings Page</h2>
         <p>Here you can configure your settings.</p>
+        <div class="count-display">{{ count }}</div>
         <button class="reset-button" @click="resetCounter">Reset</button>
         <button class="decrement-button" @click="decrementCounter">-</button>
         <button class="save-button" @click="saveChanges">Save</button>
@@ -21,23 +22,31 @@
 
 <script setup lang="ts">
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
+import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 
+const count = ref(0);
 const router = useRouter();
 
+onMounted(() => {
+  const storedCount = localStorage.getItem('count');
+  if (storedCount !== null) {
+    count.value = parseInt(storedCount, 10);
+  }
+});
+
 function resetCounter() {
-  localStorage.setItem('count', '0');
+  count.value = 0;
 }
 
 function decrementCounter() {
-  const storedCount = localStorage.getItem('count');
-  if (storedCount !== null) {
-    const count = parseInt(storedCount, 10);
-    localStorage.setItem('count', (count - 1).toString());
+  if (count.value > 0) {
+    count.value--;
   }
 }
 
 function saveChanges() {
+  localStorage.setItem('count', count.value.toString());
   router.push('/home');
 }
 
@@ -59,6 +68,12 @@ function cancelChanges() {
 
 .settings-container p {
   font-size: 18px;
+}
+
+.count-display {
+  font-size: 48px;
+  text-align: center;
+  margin-top: 20px;
 }
 
 .reset-button,

--- a/tests/e2e/specs/test.cy.ts
+++ b/tests/e2e/specs/test.cy.ts
@@ -30,3 +30,55 @@ describe('Home Page Tests', () => {
     })
   })
 })
+
+describe('Settings Page Tests', () => {
+  it('Checks if the count is displayed on the settings page', () => {
+    localStorage.setItem('count', '5');
+    cy.visit('/settings')
+    cy.get('.count-display').should('contain', '5')
+  })
+
+  it('Checks if the "Reset" button updates the displayed count without changing the stored value', () => {
+    localStorage.setItem('count', '5');
+    cy.visit('/settings')
+    cy.get('.reset-button').click()
+    cy.get('.count-display').should('contain', '0')
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('count')).to.equal('5')
+    })
+  })
+
+  it('Checks if the "Decrement" button updates the displayed count without changing the stored value', () => {
+    localStorage.setItem('count', '5');
+    cy.visit('/settings')
+    cy.get('.decrement-button').click()
+    cy.get('.count-display').should('contain', '4')
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('count')).to.equal('5')
+    })
+  })
+
+  it('Checks if the "Save" button sets the stored value to the displayed count and navigates to the home page', () => {
+    localStorage.setItem('count', '5');
+    cy.visit('/settings')
+    cy.get('.decrement-button').click()
+    cy.get('.count-display').should('contain', '4')
+    cy.get('.save-button').click()
+    cy.url().should('include', '/home')
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('count')).to.equal('4')
+    })
+  })
+
+  it('Checks if the "Cancel" button navigates to the home page without saving any changes', () => {
+    localStorage.setItem('count', '5');
+    cy.visit('/settings')
+    cy.get('.decrement-button').click()
+    cy.get('.count-display').should('contain', '4')
+    cy.get('.cancel-button').click()
+    cy.url().should('include', '/home')
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('count')).to.equal('5')
+    })
+  })
+})


### PR DESCRIPTION
Fixes #13

Add count display and update functionality to settings page.

* Add a `count` variable to store the displayed count in `src/views/SettingsPage.vue`.
* Display the `count` variable in the template.
* Update the `resetCounter` function to reset the `count` variable.
* Update the `decrementCounter` function to decrement the `count` variable.
* Update the `saveChanges` function to set the stored value to the `count` variable and navigate to the home page.
* Add tests in `tests/e2e/specs/test.cy.ts` to check if the count is displayed, the 'Reset' button updates the displayed count without changing the stored value, the 'Decrement' button updates the displayed count without changing the stored value, the 'Save' button sets the stored value to the displayed count and navigates to the home page, and the 'Cancel' button navigates to the home page without saving any changes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/notch/pull/14?shareId=d9ca0926-0963-4051-94f2-62afa87562ac).