### PR TITLE
Refresh displayed count when navigating between pages

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -16,13 +16,21 @@
 
 <script setup lang="ts">
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
-import { ref, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
+import { ref, onMounted, watch } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
 
 const count = ref(0);
 const router = useRouter();
+const route = useRoute();
 
 onMounted(() => {
+  const storedCount = localStorage.getItem('count');
+  if (storedCount !== null) {
+    count.value = parseInt(storedCount, 10);
+  }
+});
+
+watch(route, () => {
   const storedCount = localStorage.getItem('count');
   if (storedCount !== null) {
     count.value = parseInt(storedCount, 10);

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -22,13 +22,21 @@
 
 <script setup lang="ts">
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
-import { ref, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
+import { ref, onMounted, watch } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
 
 const count = ref(0);
 const router = useRouter();
+const route = useRoute();
 
 onMounted(() => {
+  const storedCount = localStorage.getItem('count');
+  if (storedCount !== null) {
+    count.value = parseInt(storedCount, 10);
+  }
+});
+
+watch(route, () => {
   const storedCount = localStorage.getItem('count');
   if (storedCount !== null) {
     count.value = parseInt(storedCount, 10);

--- a/tests/e2e/specs/test.cy.ts
+++ b/tests/e2e/specs/test.cy.ts
@@ -29,6 +29,15 @@ describe('Home Page Tests', () => {
       expect(win.localStorage.getItem('count')).to.equal('1')
     })
   })
+
+  it('Checks if the count refreshes correctly when navigating from the home page to the settings page', () => {
+    localStorage.setItem('count', '5');
+    cy.visit('/')
+    cy.get('.number-display').should('contain', '5')
+    cy.get('.settings-button').click()
+    cy.url().should('include', '/settings')
+    cy.get('.count-display').should('contain', '5')
+  })
 })
 
 describe('Settings Page Tests', () => {
@@ -80,5 +89,14 @@ describe('Settings Page Tests', () => {
     cy.window().then((win) => {
       expect(win.localStorage.getItem('count')).to.equal('5')
     })
+  })
+
+  it('Checks if the count refreshes correctly when navigating from the settings page to the home page', () => {
+    localStorage.setItem('count', '5');
+    cy.visit('/settings')
+    cy.get('.count-display').should('contain', '5')
+    cy.get('.cancel-button').click()
+    cy.url().should('include', '/home')
+    cy.get('.number-display').should('contain', '5')
   })
 })


### PR DESCRIPTION
Fixes #15

Add functionality to refresh the displayed count from the locally stored value when navigating between the home page and the settings page.

* **HomePage.vue**
  - Import `watch` from `vue` and `useRoute` from `vue-router`.
  - Add a `watch` function to observe route changes and reload the count from local storage.

* **SettingsPage.vue**
  - Import `watch` from `vue` and `useRoute` from `vue-router`.
  - Add a `watch` function to observe route changes and reload the count from local storage.

* **test.cy.ts**
  - Add a test to verify that the count refreshes correctly when navigating from the home page to the settings page.
  - Add a test to verify that the count refreshes correctly when navigating from the settings page to the home page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/notch/pull/16?shareId=13c03c0f-023d-4658-ae6d-b293cbe9349b).