### PR TITLE
Settings button should display a cog icon, not the word 'Settings'

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -9,13 +9,15 @@
     <ion-content :fullscreen="true">
       <div class="number-display">{{ count }}</div>
       <button class="count-button" @click="incrementCount">count</button>
-      <button class="settings-button" @click="goToSettings">Settings</button>
+      <button class="settings-button" @click="goToSettings">
+        <ion-icon name="cog"></ion-icon>
+      </button>
     </ion-content>
   </ion-page>
 </template>
 
 <script setup lang="ts">
-import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar, IonIcon } from '@ionic/vue';
 import { ref, onMounted, watch } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 


### PR DESCRIPTION
Fixes #19

Update the "Settings" button to display a cog icon instead of the word "Settings".

* Replace the "Settings" button text with an `ion-icon` component displaying a cog icon in `src/views/HomePage.vue`.
* Import the `IonIcon` component from `@ionic/vue` in `src/views/HomePage.vue`.
* Add the `name` attribute to the `ion-icon` component with the value "cog" in `src/views/HomePage.vue`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/notch/pull/20?shareId=c4bc5062-c2a2-4fd4-9ab3-66f2284dec06).