### PR TITLE
Fix cog icon in HomePage.vue

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -10,7 +10,7 @@
       <div class="number-display">{{ count }}</div>
       <button class="count-button" @click="incrementCount">count</button>
       <button class="settings-button" @click="goToSettings">
-        <ion-icon name="cog"></ion-icon>
+        <ion-icon :icon="cog"></ion-icon>
       </button>
     </ion-content>
   </ion-page>
@@ -18,6 +18,7 @@
 
 <script setup lang="ts">
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar, IonIcon } from '@ionic/vue';
+import { cog } from 'ionicons/icons';
 import { ref, onMounted, watch } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 


### PR DESCRIPTION
Fixes #21

Update the cog icon usage in `src/views/HomePage.vue`.

* Import the `cog` icon from `ionicons/icons`.
* Modify the `ion-icon` component to use the `cog` icon.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/notch/pull/22?shareId=2751e560-7978-4eb0-a036-4b4765405013).