### PR TITLE
Use the settings icon instead of cog

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -10,7 +10,7 @@
       <div class="number-display">{{ count }}</div>
       <button class="count-button" @click="incrementCount">count</button>
       <button class="settings-button" @click="goToSettings">
-        <ion-icon :icon="cog"></ion-icon>
+        <ion-icon :icon="settings"></ion-icon>
       </button>
     </ion-content>
   </ion-page>
@@ -18,7 +18,7 @@
 
 <script setup lang="ts">
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar, IonIcon } from '@ionic/vue';
-import { cog } from 'ionicons/icons';
+import { settings } from 'ionicons/icons';
 import { ref, onMounted, watch } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 


### PR DESCRIPTION
Fixes #23

Replace the "cog" icon with the "settings" icon in the `src/views/HomePage.vue` file.

* Update the import statement to import the "settings" icon from `ionicons/icons`.
* Replace the `cog` icon with the `settings` icon in the template.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/notch/pull/24?shareId=81714334-05f4-4662-a139-40e4fe7fe512).