### PR TITLE
Replace all of the buttons with native ones

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -8,8 +8,8 @@
 
     <ion-content :fullscreen="true">
       <div class="number-display">{{ count }}</div>
-      <button class="count-button" @click="incrementCount">count</button>
-      <button class="settings-button" @click="goToSettings">
+      <button @click="incrementCount">count</button>
+      <button @click="goToSettings">
         <ion-icon :icon="settings"></ion-icon>
       </button>
     </ion-content>
@@ -55,19 +55,5 @@ function goToSettings() {
   font-size: 48px;
   text-align: center;
   margin-top: 20%;
-}
-
-.count-button {
-  display: block;
-  margin: 20px auto;
-  padding: 10px 20px;
-  font-size: 24px;
-}
-
-.settings-button {
-  display: block;
-  margin: 20px auto;
-  padding: 10px 20px;
-  font-size: 24px;
 }
 </style>

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -11,10 +11,10 @@
         <h2>Settings Page</h2>
         <p>Here you can configure your settings.</p>
         <div class="count-display">{{ count }}</div>
-        <button class="reset-button" @click="resetCounter">Reset</button>
-        <button class="decrement-button" @click="decrementCounter">-</button>
-        <button class="save-button" @click="saveChanges">Save</button>
-        <button class="cancel-button" @click="cancelChanges">Cancel</button>
+        <button @click="resetCounter">Reset</button>
+        <button @click="decrementCounter">-</button>
+        <button @click="saveChanges">Save</button>
+        <button @click="cancelChanges">Cancel</button>
       </div>
     </ion-content>
   </ion-page>
@@ -84,10 +84,7 @@ function cancelChanges() {
   margin-top: 20px;
 }
 
-.reset-button,
-.decrement-button,
-.save-button,
-.cancel-button {
+button {
   display: block;
   margin: 10px auto;
   padding: 10px 20px;


### PR DESCRIPTION
Fixes #25

Replace custom-styled buttons with native buttons in `HomePage.vue` and `SettingsPage.vue`.

* **HomePage.vue**
  - Replace custom-styled `count-button` with a native button.
  - Replace custom-styled `settings-button` with a native button.
  - Remove custom CSS classes for `count-button` and `settings-button`.

* **SettingsPage.vue**
  - Replace custom-styled `reset-button` with a native button.
  - Replace custom-styled `decrement-button` with a native button.
  - Replace custom-styled `save-button` with a native button.
  - Replace custom-styled `cancel-button` with a native button.
  - Remove custom CSS classes for `reset-button`, `decrement-button`, `save-button`, and `cancel-button`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/notch/pull/26?shareId=488802c5-fe1b-4922-b4e2-fe7f4f4917d8).