### PR TITLE
The settings button should be displayed to the right of the count button

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -7,11 +7,13 @@
     </ion-header>
 
     <ion-content :fullscreen="true">
-      <div class="number-display">{{ count }}</div>
-      <button class="count-button" @click="incrementCount">count</button>
-      <button class="settings-button" @click="goToSettings">
-        <ion-icon :icon="settings"></ion-icon>
-      </button>
+      <div class="button-container">
+        <div class="number-display">{{ count }}</div>
+        <button class="count-button" @click="incrementCount">count</button>
+        <button class="settings-button" @click="goToSettings">
+          <ion-icon :icon="settings"></ion-icon>
+        </button>
+      </div>
     </ion-content>
   </ion-page>
 </template>
@@ -58,16 +60,22 @@ function goToSettings() {
 }
 
 .count-button {
-  display: block;
-  margin: 20px auto;
+  display: inline-block;
+  margin: 20px;
   padding: 10px 20px;
   font-size: 24px;
 }
 
 .settings-button {
-  display: block;
-  margin: 20px auto;
+  display: inline-block;
+  margin: 20px;
   padding: 10px 20px;
   font-size: 24px;
+}
+
+.button-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 </style>


### PR DESCRIPTION
Fixes #27

Update the layout of the settings button to be displayed to the right of the "count" button.

* Wrap the buttons and number display in a new `button-container` div.
* Update the `count-button` and `settings-button` styles to use `display: inline-block` and adjust margins.
* Add a new style for the `button-container` to use `display: flex` with `justify-content: center` and `align-items: center`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/notch/pull/28?shareId=a709dae6-b017-4f1a-909a-2d6805bdbdc5).