### PR TITLE
Fix button alignment on HomePage

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -8,10 +8,12 @@
 
     <ion-content :fullscreen="true">
       <div class="number-display">{{ count }}</div>
-      <button class="count-button" @click="incrementCount">count</button>
-      <button class="settings-button" @click="goToSettings">
-        <ion-icon :icon="settings"></ion-icon>
-      </button>
+      <div class="button-container">
+        <button class="count-button" @click="incrementCount">count</button>
+        <button class="settings-button" @click="goToSettings">
+          <ion-icon :icon="settings"></ion-icon>
+        </button>
+      </div>
     </ion-content>
   </ion-page>
 </template>
@@ -57,15 +59,19 @@ function goToSettings() {
   margin-top: 20%;
 }
 
+.button-container {
+  text-align: center;
+}
+
 .count-button {
-  display: block;
+  display: inline-block;
   margin: 20px auto;
   padding: 10px 20px;
   font-size: 24px;
 }
 
 .settings-button {
-  display: block;
+  display: inline-block;
   margin: 20px auto;
   padding: 10px 20px;
   font-size: 24px;


### PR DESCRIPTION
Fixes #27

Adjust the layout of the settings and count buttons to display them inline and centered.

* **Add parent container**: Wrap the `count-button` and `settings-button` in a `button-container` div.
* **Update button styles**: Set `display: inline-block` for `count-button` and `settings-button`.
* **Center buttons**: Add `text-align: center` to `button-container` to center the buttons horizontally.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/notch/pull/29?shareId=e58184b6-e405-4e93-a333-c8d819719ce4).