### PR TITLE
Move the count and settings buttons closer to the centre of the home page

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -61,6 +61,11 @@ function goToSettings() {
 
 .button-container {
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
 }
 
 .count-button {
@@ -75,11 +80,5 @@ function goToSettings() {
   margin: 20px auto;
   padding: 10px 20px;
   font-size: 24px;
-}
-
-.button-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
 }
 </style>


### PR DESCRIPTION
Fixes #30

Update the CSS in `src/views/HomePage.vue` to center the count and settings buttons vertically and horizontally.

* Add `display: flex`, `flex-direction: column`, `justify-content: center`, `align-items: center`, and `height: 100vh` to the `.button-container` class to center the buttons vertically and horizontally.
* Remove the redundant `.button-container` class at the end of the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/notch/pull/31?shareId=b0df9d78-a2f3-4f2a-a913-de3498641e96).